### PR TITLE
Game Starting Scene / AnomalyManager adjusted

### DIFF
--- a/302/Assets/Scenes/GameStartingScene.unity
+++ b/302/Assets/Scenes/GameStartingScene.unity
@@ -4472,7 +4472,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 17
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &227027812
 PrefabInstance:
@@ -37144,74 +37144,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7236329420339151181, guid: 2ad42fc20dee64e4ca84470ffa3fb42e, type: 3}
   m_PrefabInstance: {fileID: 1756427539}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1760917402
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1760917405}
-  - component: {fileID: 1760917404}
-  - component: {fileID: 1760917403}
-  m_Layer: 0
-  m_Name: EventSystem (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1760917403
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1760917402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
-  m_HorizontalAxis: Horizontal
-  m_VerticalAxis: Vertical
-  m_SubmitButton: Submit
-  m_CancelButton: Cancel
-  m_InputActionsPerSecond: 10
-  m_RepeatDelay: 0.5
-  m_ForceModuleActive: 0
---- !u!114 &1760917404
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1760917402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_FirstSelected: {fileID: 0}
-  m_sendNavigationEvents: 1
-  m_DragThreshold: 10
---- !u!4 &1760917405
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1760917402}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1762837216
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -41279,7 +41211,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1879079609
 PrefabInstance:

--- a/302/Assets/Scripts/AnomalyManager.cs
+++ b/302/Assets/Scripts/AnomalyManager.cs
@@ -64,9 +64,15 @@ public class AnomalyManager : MonoBehaviour
     public void CheckAndInstantiateAnomaly()
     {
         int stageIndex = GameManager.Instance.GetCurrentStage() - 1;
-        if (stageIndex < 0 || stageIndex >= anomalyList.Count)
+        if (stageIndex >= anomalyList.Count)
         {
             Debug.LogError("Invalid stage index in anomaly list.");
+            return;
+        } 
+        else if (stageIndex == -1)
+        {
+            Debug.Log($"[AnomalyManager] Current Stage : {GameManager.Instance.GetCurrentStage()}");
+            currentAnomalyInstance = Instantiate(anomalyPrefabs[0]);
             return;
         }
         int anomaly = anomalyList[stageIndex];


### PR DESCRIPTION
1. AnomalyManager가 0스테이지에서 잘못된 색인을 참조하는 경우, return처리하던 기존의 코드에서 defaultscene을 로드하는 것으로(겉보기에 차이는 없음) 수정했습니다.
2. 게임 스타팅 씬에 존재하던 두 개의 이벤트 시스템을 한 개로 줄였습니다.
3. 스타팅 씬에서 화면이 두 번 깜빡이고, 이후 디폴트 씬이 로드되는 것은 기획한 부분입니다!
4. 남학생의 눈이 안 보이는 것은, 위치는 잘 지정되어 있는데, 아무래도 유니티에서 material을 처리하는 과정에서 생긴 문제인 것으로 보입니다. 책상의 플러그라던가 교탁의 양동이 등도 부분적으로 투명(뒤의 물체가 보임)해지는 문제가 발생하는데, testing과 refactoring단계에서 고쳐야 할 듯 합니다!