### PR TITLE
Anomaly27(magnifying clock) revised

### DIFF
--- a/302/Assets/Scripts/AnomalyManager.cs
+++ b/302/Assets/Scripts/AnomalyManager.cs
@@ -11,6 +11,7 @@ public class AnomalyManager : MonoBehaviour
     private const int AnomalyCount = 8;                 // 사이즈 8
     private System.Random random = new System.Random();
     public bool checkSpecificAnomaly;
+    public bool checkIntersect;
     public int SpecificAnomalyNum;
     public GameObject currentAnomalyInstance;          // 현재 활성화된 이상현상 인스턴스
     // 하나의 AnomalyManager만 보장
@@ -48,7 +49,8 @@ public class AnomalyManager : MonoBehaviour
             }
             else
             {
-                anomaly = SpecificAnomalyNum;
+                if(checkIntersect && i%2==1) anomaly = 0;
+                else anomaly = SpecificAnomalyNum;
             }
             anomalyList.Add(anomaly);
         }

--- a/302/Assets/Scripts/SpecificAnomalyManager/Anomaly27Manager.cs
+++ b/302/Assets/Scripts/SpecificAnomalyManager/Anomaly27Manager.cs
@@ -4,24 +4,10 @@ using UnityEngine;
 
 public class Anomaly27Manager : MonoBehaviour
 {
-    public string targetObjectName = "clock";    // 비활성화할 게임 오브젝트 이름
     public GameObject clockPrefab;               // 소환할 프리팹
 
     private void Start()
     {
-        // 특정 이름의 게임 오브젝트 찾기
-        GameObject targetObject = GameObject.Find(targetObjectName);
-        if (targetObject != null)
-        {
-            // 게임 오브젝트 비활성화
-            targetObject.SetActive(false);
-            Debug.Log($"Anomaly 27: Found and deactivated target object {targetObjectName}");
-        }
-        else
-        {
-            Debug.LogWarning($"Anomaly 27: Target object {targetObjectName} not found in the scene.");
-        }
-
         // 프리팹 소환
         if (clockPrefab != null)
         {


### PR DESCRIPTION
# PR Title [Magnifying Clock 활성화 시, 기본 시계 비활성화 문제 해결] 
## Related Issues
AnomalyManager, Anomaly27Manager
## PR Description
[이상현상 27 발현 후, 기본 시계가 보이지 않는 문제를 해결하기 위해 몇 가지 수정했습니다. 
먼저, 특정 이상현상을 테스트할 때 기본 씬과의 호환을 살펴보기 위해 bool 형 변수 'checkIntersect'를 추가해, 이를 활성화 할 시 이상현상 0(디폴트 씬) 과 선택한 이상현상이 번갈아 나옵니다. 선택한 이상현상이 홀수, 기본 씬이 짝수 스테이지에 나옵니다.] 

### Changes Included
- [x] Added new feature(s)
- [x] Fixed identified bug(s)
- [x] Updated relevant documentation

### Notes for Reviewer
없음
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified. ---
## Additional Comments
없음