### PR TITLE
fixEndingScene

### DIFF
--- a/302/Assets/Scenes/GameEndingScene.unity
+++ b/302/Assets/Scenes/GameEndingScene.unity
@@ -9656,6 +9656,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: e8452d6febdb74d3baa023ccec6ad5d2, type: 3}
   m_PrefabInstance: {fileID: 515213778}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &517491601 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: fd767fe10a8c14c998f585458f438e70, type: 3}
+  m_PrefabInstance: {fileID: 1412558968}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &521140340
 GameObject:
   m_ObjectHideFlags: 0
@@ -14298,6 +14303,11 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: e8452d6febdb74d3baa023ccec6ad5d2, type: 3}
   m_PrefabInstance: {fileID: 707265331}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &709228346 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: c6a9d5739aa8a4ef89786317c6058cc0, type: 3}
+  m_PrefabInstance: {fileID: 1383604116}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &709916359
 PrefabInstance:
@@ -28287,6 +28297,19 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c6a9d5739aa8a4ef89786317c6058cc0, type: 3}
   m_PrefabInstance: {fileID: 1383604116}
   m_PrefabAsset: {fileID: 0}
+--- !u!65 &1383604120
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 709228346}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.0090263365, y: 0.053499296, z: 0.13540304}
+  m_Center: {x: 0.0024651717, y: 0.0075524854, z: 0}
 --- !u!1001 &1397042809
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -28628,6 +28651,19 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: fd767fe10a8c14c998f585458f438e70, type: 3}
   m_PrefabInstance: {fileID: 1412558968}
   m_PrefabAsset: {fileID: 0}
+--- !u!65 &1412558972
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517491601}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.031955995, y: 0.44247913, z: 0.12539476}
+  m_Center: {x: 0, y: 0.044278048, z: 1.8189894e-12}
 --- !u!1001 &1414771487
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -29184,6 +29220,24 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1809372938388778512, guid: 474138867ca9be144953fa0ca636b7c9, type: 3}
   m_PrefabInstance: {fileID: 1432105712}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1433790063 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 7e9cbea5074b04a75a2815824ed26ba1, type: 3}
+  m_PrefabInstance: {fileID: 590275684}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1433790066
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1433790063}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.008953055, y: 0.34407064, z: 0.13540304}
+  m_Center: {x: -0.0024284937, y: -1.0587912e-22, z: -0.000000009888056}
 --- !u!1001 &1436602646
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -32985,6 +33039,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33b91f25b1ae6fa4d9727b23d45aab6a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  position: {x: 0, y: 0, z: 0}
+  direction: {x: 0, y: 0, z: 0}
+  valueNormal: 0
+  valueAnomaly: 0
+  duration: 0
 --- !u!1001 &1679000449
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -34125,6 +34184,10 @@ PrefabInstance:
     - target: {fileID: 3485807839047865911, guid: 39b6a49b196d7a8479b1c58bebb4cb7b, type: 3}
       propertyPath: m_Name
       value: SlideLeft
+      objectReference: {fileID: 0}
+    - target: {fileID: 3485807839047865911, guid: 39b6a49b196d7a8479b1c58bebb4cb7b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3485807839047865914, guid: 39b6a49b196d7a8479b1c58bebb4cb7b, type: 3}
       propertyPath: m_RootOrder
@@ -36612,6 +36675,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: SlideRight
       objectReference: {fileID: 0}
+    - target: {fileID: 3485807839047865911, guid: 39b6a49b196d7a8479b1c58bebb4cb7b, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3485807839047865914, guid: 39b6a49b196d7a8479b1c58bebb4cb7b, type: 3}
       propertyPath: m_RootOrder
       value: 5
@@ -38769,6 +38836,24 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+--- !u!1 &1926101424 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 12de81f0b40f54f13bcc99b854a8286a, type: 3}
+  m_PrefabInstance: {fileID: 1436602646}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &1926101427
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926101424}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.024931962, y: 0.034303553, z: 0.13799092}
+  m_Center: {x: -0.0021075164, y: -0.0000000047683715, z: 0}
 --- !u!1001 &1935816555
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -43649,7 +43734,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5403613182878368489}
   m_LocalRotation: {x: 0, y: 0.7072302, z: 0.7069834, w: 0}
-  m_LocalPosition: {x: 18.499, y: 0, z: -12.269}
+  m_LocalPosition: {x: 17.67, y: 0.17, z: -12.27}
   m_LocalScale: {x: 120, y: 120, z: 120}
   m_ConstrainProportionsScale: 0
   m_Children:


### PR DESCRIPTION
# PR Title [엔딩씬 수정]
## Related Issue(s)
엔딩씬 관련 오브젝트
## PR Description
엔딩씬에서 슬라이드 내용과 노트북이 사라지게 했습니다. 엔딩씬에서 벽이 뚫리던 문제를 collider를 추가해 해결했습니다.
### Changes Included
- [ ] Added new feature(s)
- [X] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
<img width="671" alt="스크린샷 2024-11-26 10 30 01" src="https://github.com/user-attachments/assets/fd29c323-d39e-4e92-ade5-2e6b3d913394">

### Notes for Reviewer
없음
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
없음
